### PR TITLE
link runtime staticly on msvc toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ services: docker
 
 language: rust
 script:
-  - cargo build --verbose --release
+  # On windows we want to link the C-Runtime statically.
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+      cargo rustc --release -- -C target-feature=+crt-static
+    else
+      cargo build --verbose --release
+    fi
   - cargo test --verbose --release
 rust:
   - stable

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.0.9
+-----
+
+* Updated dependencies
+* Visual C Runtime is now linked statically into windows executable and no longer a runtime requirement.
+* Build with Rust 1.35.0
+
 1.0.8
 -----
 


### PR DESCRIPTION
Removes dynamic dependency to Visual C++ Runtime